### PR TITLE
apiserver-proxy: exclude WALinux agent from yum update

### DIFF
--- a/modules/azure/master/api-proxy.tf
+++ b/modules/azure/master/api-proxy.tf
@@ -59,7 +59,7 @@ gpgcheck=0
 enabled=1
 NGINXREPO'
 
-sudo yum update -y
+sudo yum update --exclude=WALinuxAgent* -y
 sudo yum install -y nginx
 
 sudo bash -c 'cat > nginx.conf << "NGINXCONF"


### PR DESCRIPTION
Using the WALinux agent to execute a bootstrap script via the linux extension
seems to try and update itself while it's active, affecting the script in
process.