### PR TITLE
azure/nsg: fix conditional & resource_group_name for console NSG

### DIFF
--- a/modules/azure/vnet/nsg-lb.tf
+++ b/modules/azure/vnet/nsg-lb.tf
@@ -36,10 +36,10 @@ resource "azurerm_network_security_rule" "api_ingress_https" {
 }
 
 resource "azurerm_network_security_group" "console" {
-  count               = "${var.create_api_nsg_rules ? 1 : 0}"
+  count               = "${var.external_api_nsg_name == "" ? 1 : 0}"
   name                = "${var.tectonic_cluster_name}-console-nsg"
   location            = "${var.location}"
-  resource_group_name = "${var.external_nsg_rsg_name}"
+  resource_group_name = "${var.resource_group_name}"
 }
 
 resource "azurerm_network_security_rule" "console_egress" {


### PR DESCRIPTION
This fixes the issue in:

```
Error applying plan:

1 error(s) occurred:

* module.vnet.azurerm_network_security_group.console (destroy): 1 error(s) occurred:

* azurerm_network_security_group.console: network.SecurityGroupsClient#Delete: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailed" Message="The client '<CLIENT_ID>' with object id '<OBJECT_ID>' does not have authorization to perform action 'Microsoft.Network/networkSecurityGroups/delete' over scope '/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP>/providers/Microsoft.Network/networkSecurityGroups/myprefix-metral071-console-nsg'.
```