### PR TITLE
Add existing certificate support.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -265,6 +265,34 @@ Note: This field MUST be set manually prior to creating the cluster.
 EOF
 }
 
+# Existing Certs.
+variable "tectonic_existing_certs" {
+  description = <<EOF
+A set of paths that point to tls assets that have been pregenerated for the cluster. You can provide as many or as few certs as desired. The certificate files can include an intermediate certificate if necessary.
+ca_crt_path:         The file location of a PEM-encoded CA certificate, used to generate the certificates that we will use to secure the tls enabled endpoints in tectonic.
+ca_key_path:         The file location of a PEM-encoded CA key, used to sign all of the generated certificates. If left blank one will be generated.
+ca_key_alg:          The algorithm used to generate the ca_key. The default value is recommended. This field is mandatory if `ca_key` is set.
+ingress_crt_path:    The file location of the certificate that will be used to secure the ingress controller in front of the console and identity services.
+                     This certificate should have the CN and Subject Alternate Name set. See RFC2818 for details
+ingress_key_path:    The file location of the key that will be used to secure the ingress controller in front of the console and identity services.
+apiserver_cert_path: The file location of the certificate that will be used to secure communication with the kube apiserver.
+                     This certificate should have the following Subject Alternate Names set: "The common name used to address the api server", "kubernetes", "kubernetes.default",¬"kubernetes.default.svc",¬"kubernetes.default.svc.cluster.local" and a SAN IP of 10.3.0.1
+apiserver_key_path:  The file location of the key that will be used to secure communication with the kube apiserver.
+EOF
+
+  type = "map"
+
+  default = {
+    ca_cert_path        = "/dev/null"
+    ca_key_path         = "/dev/null"
+    ca_key_alg          = "RSA"
+    ingress_cert_path   = "/dev/null"
+    ingress_key_path    = "/dev/null"
+    apiserver_cert_path = "/dev/null"
+    apiserver_key_path  = "/dev/null"
+  }
+}
+
 variable "tectonic_ca_cert" {
   type    = "string"
   default = ""

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -96,9 +96,10 @@ resource "template_dir" "bootkube" {
     oidc_username_claim = "${var.oidc_username_claim}"
     oidc_groups_claim   = "${var.oidc_groups_claim}"
 
-    ca_cert            = "${base64encode(var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert)}"
-    apiserver_key      = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
-    apiserver_cert     = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"
+    ca_cert            = "${base64encode(var.existing_certs["ca_cert_path"] == "/dev/null" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : "${file(var.existing_certs["ca_cert_path"])}${tls_self_signed_cert.kube-ca.0.cert_pem}")}"
+    client_ca_cert     = "${base64encode(tls_self_signed_cert.kube-ca.0.cert_pem)}"
+    apiserver_key      = "${base64encode(var.existing_certs["apiserver_cert_path"] == "/dev/null" ? join(" ", tls_private_key.apiserver.*.private_key_pem) : file(var.existing_certs["apiserver_key_path"]))}"
+    apiserver_cert     = "${base64encode(var.existing_certs["apiserver_cert_path"] == "/dev/null" ? join(" ", tls_locally_signed_cert.apiserver.*.cert_pem) : file(var.existing_certs["apiserver_cert_path"]))}"
     serviceaccount_pub = "${base64encode(tls_private_key.service-account.public_key_pem)}"
     serviceaccount_key = "${base64encode(tls_private_key.service-account.private_key_pem)}"
 
@@ -160,7 +161,7 @@ data "template_file" "kubeconfig" {
   template = "${file("${path.module}/resources/kubeconfig")}"
 
   vars {
-    ca_cert      = "${base64encode(var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert)}"
+    ca_cert      = "${base64encode(var.existing_certs["ca_cert_path"] == "/dev/null" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : "${file(var.existing_certs["ca_cert_path"])}${tls_self_signed_cert.kube-ca.0.cert_pem}")}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
     server       = "${var.kube_apiserver_url}"

--- a/modules/bootkube/assets_tls.tf
+++ b/modules/bootkube/assets_tls.tf
@@ -1,5 +1,5 @@
 # NOTE: Across this module, the following syntax is used at various places:
-#   `"${var.ca_cert == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_key}"`
+#   `"${var.existing_certs["ca_crt_path"] == "/dev/null" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.existing_certs["ca_key"]}"`
 #
 # Due to https://github.com/hashicorp/hil/issues/50, both sides of conditions
 # are evaluated, until one of them is discarded. Unfortunately, the
@@ -13,14 +13,14 @@
 
 # Kubernetes CA (resources/generated/tls/{ca.crt,ca.key})
 resource "tls_private_key" "kube-ca" {
-  count = "${var.ca_cert == "" ? 1 : 0}"
+  count = "${var.existing_certs["ca_key_path"] == "/dev/null" ? 1 : 0}"
 
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_self_signed_cert" "kube-ca" {
-  count = "${var.ca_cert == "" ? 1 : 0}"
+  count = "${var.existing_certs["ca_key_path"] == "/dev/null" ? 1 : 0}"
 
   key_algorithm   = "${tls_private_key.kube-ca.algorithm}"
   private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
@@ -41,22 +41,32 @@ resource "tls_self_signed_cert" "kube-ca" {
 }
 
 resource "local_file" "kube-ca-key" {
-  content  = "${var.ca_cert == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_key}"
+  content  = "${var.existing_certs["ca_key_path"] == "/dev/null" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : file(var.existing_certs["ca_key_path"])}"
   filename = "./generated/tls/ca.key"
 }
 
+#This is a ca bundle of the supplied ca.crt and the generated one.
 resource "local_file" "kube-ca-crt" {
-  content  = "${var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert}"
+  content  = "${var.existing_certs["ca_cert_path"] == "/dev/null" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : "${file(var.existing_certs["ca_cert_path"])}${tls_self_signed_cert.kube-ca.0.cert_pem}"}"
   filename = "./generated/tls/ca.crt"
+}
+
+#This cert will be used as --client-ca-file any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.
+
+resource "local_file" "kube-client-ca" {
+  content  = "${tls_self_signed_cert.kube-ca.0.cert_pem}"
+  filename = "./generated/tls/client-ca.crt"
 }
 
 # Kubernetes API Server (resources/generated/tls/{apiserver.key,apiserver.crt})
 resource "tls_private_key" "apiserver" {
+  count     = "${var.existing_certs["apiserver_key_path"] == "/dev/null" ? 1 : 0}"
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_cert_request" "apiserver" {
+  count           = "${var.existing_certs["apiserver_key_path"] == "/dev/null" ? 1 : 0}"
   key_algorithm   = "${tls_private_key.apiserver.algorithm}"
   private_key_pem = "${tls_private_key.apiserver.private_key_pem}"
 
@@ -79,11 +89,12 @@ resource "tls_cert_request" "apiserver" {
 }
 
 resource "tls_locally_signed_cert" "apiserver" {
+  count            = "${var.existing_certs["apiserver_key_path"] == "/dev/null" ? 1 : 0}"
   cert_request_pem = "${tls_cert_request.apiserver.cert_request_pem}"
 
-  ca_key_algorithm   = "${var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.ca_key_alg}"
-  ca_private_key_pem = "${var.ca_cert == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_key}"
-  ca_cert_pem        = "${var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem): var.ca_cert}"
+  ca_key_algorithm   = "${var.existing_certs["ca_key_path"] == "/dev/null" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.existing_certs["ca_key_alg"]}"
+  ca_private_key_pem = "${var.existing_certs["ca_key_path"] == "/dev/null" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.existing_certs["ca_key_path"]}"
+  ca_cert_pem        = "${var.existing_certs["ca_key_path"] == "/dev/null" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : file(var.existing_certs["ca_cert_path"])}"
 
   validity_period_hours = 8760
 
@@ -96,12 +107,12 @@ resource "tls_locally_signed_cert" "apiserver" {
 }
 
 resource "local_file" "apiserver-key" {
-  content  = "${tls_private_key.apiserver.private_key_pem}"
+  content  = "${var.existing_certs["apiserver_key_path"] == "/dev/null" ? join(" ", tls_private_key.apiserver.*.private_key_pem) : file(var.existing_certs["apiserver_key_path"])}"
   filename = "./generated/tls/apiserver.key"
 }
 
 resource "local_file" "apiserver-crt" {
-  content  = "${tls_locally_signed_cert.apiserver.cert_pem}"
+  content  = "${var.existing_certs["apiserver_key_path"] == "/dev/null" ? join(" ", tls_locally_signed_cert.apiserver.*.cert_pem) : file(var.existing_certs["apiserver_cert_path"])}"
   filename = "./generated/tls/apiserver.crt"
 }
 
@@ -121,7 +132,7 @@ resource "local_file" "service-account-crt" {
   filename = "./generated/tls/service-account.pub"
 }
 
-# Kubelet
+# Kubelet. This is really only used as client auth. The kubelets generate their own keys.
 resource "tls_private_key" "kubelet" {
   algorithm = "RSA"
   rsa_bits  = "2048"
@@ -140,9 +151,9 @@ resource "tls_cert_request" "kubelet" {
 resource "tls_locally_signed_cert" "kubelet" {
   cert_request_pem = "${tls_cert_request.kubelet.cert_request_pem}"
 
-  ca_key_algorithm   = "${var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.ca_key_alg}"
-  ca_private_key_pem = "${var.ca_cert == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_key}"
-  ca_cert_pem        = "${var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert}"
+  ca_key_algorithm   = "${var.existing_certs["ca_key_path"] == "/dev/null" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.existing_certs["ca_key_alg"]}"
+  ca_private_key_pem = "${var.existing_certs["ca_key_path"] == "/dev/null" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : file(var.existing_certs["ca_key_path"])}"
+  ca_cert_pem        = "${var.existing_certs["ca_key_path"] == "/dev/null" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : file(var.existing_certs["ca_cert_path"])}"
 
   validity_period_hours = 8760
 

--- a/modules/bootkube/outputs.tf
+++ b/modules/bootkube/outputs.tf
@@ -33,15 +33,15 @@ output "kubeconfig" {
 }
 
 output "ca_cert" {
-  value = "${var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert}"
+  value = "${var.existing_certs["ca_cert_path"] == "/dev/null" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : "${file(var.existing_certs["ca_cert_path"])}${tls_self_signed_cert.kube-ca.0.cert_pem}"}"
 }
 
 output "ca_key_alg" {
-  value = "${var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.ca_key_alg}"
+  value = "${var.existing_certs["ca_cert_path"] == "/dev/null" ? join(" ", tls_self_signed_cert.kube-ca.*.key_algorithm) : var.existing_certs["ca_key_alg"]}"
 }
 
 output "ca_key" {
-  value = "${var.ca_cert == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_key}"
+  value = "${var.existing_certs["ca_key_path"] == "/dev/null" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : file(var.existing_certs["ca_key_path"])}"
 }
 
 output "systemd_service" {

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -16,7 +16,7 @@ spec:
     - --allow-privileged=true
     - --authorization-mode=RBAC
     - --bind-address=0.0.0.0
-    - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+    - --client-ca-file=/etc/kubernetes/secrets/client-ca.crt
     - --cloud-provider=${cloud_provider}
     - --etcd-servers=${etcd_servers}
     ${etcd_ca_flag}

--- a/modules/bootkube/resources/manifests/kube-apiserver-secret.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver-secret.yaml
@@ -8,6 +8,7 @@ data:
   apiserver.key: ${apiserver_key}
   apiserver.crt: ${apiserver_cert}
   service-account.pub: ${serviceaccount_pub}
+  client-ca.crt: ${client_ca_cert}
   ca.crt: ${ca_cert}
   etcd-ca.crt: ${etcd_ca_cert}
   etcd-client.crt: ${etcd_client_cert}

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -47,7 +47,7 @@ spec:
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
-        - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+        - --client-ca-file=/etc/kubernetes/secrets/client-ca.crt
         - --authorization-mode=RBAC
         - --anonymous-auth=${anonymous_auth}
         - --oidc-issuer-url=${oidc_issuer_url}

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -3,6 +3,11 @@ variable "container_images" {
   type        = "map"
 }
 
+variable "existing_certs" {
+  description = "existing certs"
+  type        = "map"
+}
+
 variable "versions" {
   description = "Container versions to use"
   type        = "map"

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -53,8 +53,8 @@ resource "template_dir" "tectonic" {
     console_callback     = "https://${var.base_address}/auth/callback"
 
     ingress_kind     = "${var.ingress_kind}"
-    ingress_tls_cert = "${base64encode(tls_locally_signed_cert.ingress.cert_pem)}"
-    ingress_tls_key  = "${base64encode(tls_private_key.ingress.private_key_pem)}"
+    ingress_tls_cert = "${base64encode(var.existing_certs["ingress_cert_path"] == "/dev/null" ? join(" ", tls_locally_signed_cert.ingress.*.cert_pem) : file(var.existing_certs["ingress_cert_path"]))}"
+    ingress_tls_key  = "${base64encode(var.existing_certs["ingress_cert_path"] == "/dev/null" ? join(" ", tls_locally_signed_cert.ingress.*.private_key_pem) : file(var.existing_certs["ingress_key_path"]))}"
 
     identity_server_tls_cert = "${base64encode(tls_locally_signed_cert.identity-server.cert_pem)}"
     identity_server_tls_key  = "${base64encode(tls_private_key.identity-server.private_key_pem)}"

--- a/modules/tectonic/crypto.tf
+++ b/modules/tectonic/crypto.tf
@@ -15,11 +15,13 @@ resource "random_id" "console_secret" {
 # Ingress' server certificate
 
 resource "tls_private_key" "ingress" {
+  count     = "${var.existing_certs["ingress_key_path"] == "/dev/null" ? 1 : 0 }"
   algorithm = "RSA"
   rsa_bits  = "2048"
 }
 
 resource "tls_cert_request" "ingress" {
+  count     = "${var.existing_certs["ingress_key_path"] == "/dev/null" ? 1 : 0 }"
   key_algorithm   = "${tls_private_key.ingress.algorithm}"
   private_key_pem = "${tls_private_key.ingress.private_key_pem}"
 
@@ -35,11 +37,12 @@ resource "tls_cert_request" "ingress" {
 }
 
 resource "tls_locally_signed_cert" "ingress" {
+  count     = "${var.existing_certs["ingress_key_path"] == "/dev/null" ? 1 : 0 }"
   cert_request_pem = "${tls_cert_request.ingress.cert_request_pem}"
 
-  ca_key_algorithm   = "${var.ca_key_alg}"
-  ca_private_key_pem = "${var.ca_key}"
-  ca_cert_pem        = "${var.ca_cert}"
+  ca_key_algorithm   = "${var.existing_certs["ca_key_path"] == "/dev/null" ? var.ca_key_alg : var.existing_certs["ca_key_alg"]}"
+  ca_private_key_pem = "${var.existing_certs["ca_key_path"] == "/dev/null" ? var.ca_key : file(var.existing_certs["ca_key_path"])}"
+  ca_cert_pem        = "${var.existing_certs["ca_key_path"] == "/dev/null" ? var.ca_cert : file(var.existing_certs["ca_cert_path"])}"
 
   validity_period_hours = 8760
 
@@ -70,9 +73,9 @@ resource "tls_cert_request" "identity-server" {
 resource "tls_locally_signed_cert" "identity-server" {
   cert_request_pem = "${tls_cert_request.identity-server.cert_request_pem}"
 
-  ca_key_algorithm   = "${var.ca_key_alg}"
-  ca_private_key_pem = "${var.ca_key}"
-  ca_cert_pem        = "${var.ca_cert}"
+  ca_key_algorithm   = "${var.existing_certs["ca_key_path"] == "/dev/null" ? var.ca_key_alg : var.existing_certs["ca_key_alg"]}"
+  ca_private_key_pem = "${var.existing_certs["ca_key_path"] == "/dev/null" ? var.ca_key : file(var.existing_certs["ca_key_path"])}"
+  ca_cert_pem        = "${var.existing_certs["ca_key_path"] == "/dev/null" ? var.ca_cert : file(var.existing_certs["ca_cert_path"])}"
 
   validity_period_hours = 8760
 
@@ -98,9 +101,9 @@ resource "tls_cert_request" "identity-client" {
 resource "tls_locally_signed_cert" "identity-client" {
   cert_request_pem = "${tls_cert_request.identity-client.cert_request_pem}"
 
-  ca_key_algorithm   = "${var.ca_key_alg}"
-  ca_private_key_pem = "${var.ca_key}"
-  ca_cert_pem        = "${var.ca_cert}"
+  ca_key_algorithm   = "${var.existing_certs["ca_key_path"] == "/dev/null" ? var.ca_key_alg : var.existing_certs["ca_key_alg"]}"
+  ca_private_key_pem = "${var.existing_certs["ca_key_path"] == "/dev/null" ? var.ca_key : file(var.existing_certs["ca_key_path"])}"
+  ca_cert_pem        = "${var.existing_certs["ca_key_path"] == "/dev/null" ? var.ca_cert : file(var.existing_certs["ca_cert_path"])}"
 
   validity_period_hours = 8760
 

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -11,6 +11,11 @@ variable "container_images" {
   type        = "map"
 }
 
+variable "existing_certs" {
+  description = "existing certs"
+  type        = "map"
+}
+
 variable "versions" {
   description = "Versions of the components to use. Leave blank for defaults."
   type        = "map"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -6,6 +6,7 @@ module "bootkube" {
   oidc_issuer_url    = "https://${module.masters.ingress_internal_fqdn}/identity"
 
   # Platform-independent variables wiring, do not modify.
+  existing_certs   = "${var.tectonic_existing_certs}"
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
@@ -40,6 +41,7 @@ module "tectonic" {
   kube_apiserver_url = "https://${module.masters.api_internal_fqdn}:443"
 
   # Platform-independent variables wiring, do not modify.
+  existing_certs   = "${var.tectonic_existing_certs}"
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
@@ -87,8 +89,8 @@ resource "null_resource" "tectonic" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mkdir -p /opt",
       "sudo rm -rf /opt/tectonic",
+      "sudo mkdir -p /opt",
       "sudo mv /home/core/tectonic /opt/",
       "sudo systemctl start tectonic",
     ]


### PR DESCRIPTION
This commit does a bunch.
- Refactor existing certs to a map called tectonic-existing-certs.
- Support existing certs for securing apiserver and ingress controller.

If the user provides a ca.key path we will use that to generate certs.
If the user provides only a ca.crt we will use that in the right places
to support trust. This is implemented as a ca-bundle.