### PR TITLE
Shorten / cleanup naming conventions

### DIFF
--- a/modules/azure/etcd/etcd.tf
+++ b/modules/azure/etcd/etcd.tf
@@ -28,7 +28,7 @@ resource "azurerm_virtual_machine" "etcd_node" {
   }
 
   os_profile {
-    computer_name  = "${format("%s-%s-%03d", var.cluster_name, var.role, count.index + 1)}"
+    computer_name  = "${format("%s%s%03d", var.cluster_name, "e", count.index + 1)}"
     admin_username = "core"
     admin_password = ""
     custom_data    = "${base64encode("${data.ignition_config.etcd.*.rendered[count.index]}")}"

--- a/modules/azure/etcd/etcd.tf
+++ b/modules/azure/etcd/etcd.tf
@@ -49,7 +49,7 @@ resource "random_id" "storage" {
 }
 
 resource "azurerm_storage_account" "etcd_storage" {
-  name                = "${var.cluster_prefix}${random_id.storage.hex}etcd"
+  name                = "${var.cluster_name}${random_id.storage.hex}etcd"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"

--- a/modules/azure/etcd/etcd.tf
+++ b/modules/azure/etcd/etcd.tf
@@ -45,7 +45,7 @@ resource "azurerm_virtual_machine" "etcd_node" {
 }
 
 resource "random_id" "storage" {
-  byte_length = 4
+  byte_length = 2
 }
 
 resource "azurerm_storage_account" "etcd_storage" {

--- a/modules/azure/master-as/api-proxy.tf
+++ b/modules/azure/master-as/api-proxy.tf
@@ -23,7 +23,7 @@ variable proxy_storage_profile_image_reference {
 }
 
 resource "azurerm_storage_account" "proxy" {
-  name                = "${var.cluster_prefix}${random_id.tectonic_master_storage_name.hex}p"
+  name                = "${var.cluster_name}${random_id.tectonic_master_storage_name.hex}p"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "Standard_LRS"

--- a/modules/azure/master-as/api-proxy.tf
+++ b/modules/azure/master-as/api-proxy.tf
@@ -23,7 +23,7 @@ variable proxy_storage_profile_image_reference {
 }
 
 resource "azurerm_storage_account" "proxy" {
-  name                = "${var.cluster_prefix}${random_id.tectonic_master_storage_name.hex}proxy"
+  name                = "${var.cluster_prefix}${random_id.tectonic_master_storage_name.hex}p"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "Standard_LRS"

--- a/modules/azure/master-as/master.tf
+++ b/modules/azure/master-as/master.tf
@@ -10,7 +10,7 @@ resource "random_id" "tectonic_master_storage_name" {
 }
 
 resource "azurerm_storage_account" "tectonic_master" {
-  name                = "${var.cluster_prefix}${random_id.tectonic_master_storage_name.hex}m"
+  name                = "${var.cluster_name}${random_id.tectonic_master_storage_name.hex}m"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"

--- a/modules/azure/master-as/master.tf
+++ b/modules/azure/master-as/master.tf
@@ -6,7 +6,7 @@
 
 # Generate unique storage name
 resource "random_id" "tectonic_master_storage_name" {
-  byte_length = 4
+  byte_length = 2
 }
 
 resource "azurerm_storage_account" "tectonic_master" {

--- a/modules/azure/master-as/master.tf
+++ b/modules/azure/master-as/master.tf
@@ -72,7 +72,7 @@ resource "azurerm_virtual_machine" "tectonic_master" {
   }
 
   os_profile {
-    computer_name  = "${format("%s-%s-%03d", var.cluster_name, var.role, count.index + 1)}"
+    computer_name  = "${format("%s%s%03d", var.cluster_name, "m", count.index + 1)}"
     admin_username = "core"
     admin_password = ""
 

--- a/modules/azure/master-ss/master.tf
+++ b/modules/azure/master-ss/master.tf
@@ -10,7 +10,7 @@ resource "random_id" "tectonic_master_storage_name" {
 }
 
 resource "azurerm_storage_account" "tectonic_master" {
-  name                = "${var.cluster_prefix}${random_id.tectonic_master_storage_name.hex}m"
+  name                = "${var.cluster_name}${random_id.tectonic_master_storage_name.hex}m"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"

--- a/modules/azure/master-ss/master.tf
+++ b/modules/azure/master-ss/master.tf
@@ -6,7 +6,7 @@
 
 # Generate unique storage name
 resource "random_id" "tectonic_master_storage_name" {
-  byte_length = 4
+  byte_length = 2
 }
 
 resource "azurerm_storage_account" "tectonic_master" {

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -4,7 +4,7 @@ resource "random_id" "tectonic_storage_name" {
 }
 
 resource "azurerm_storage_account" "tectonic_worker" {
-  name                = "${var.cluster_prefix}${random_id.tectonic_storage_name.hex}wrk"
+  name                = "${var.cluster_name}${random_id.tectonic_storage_name.hex}wrk"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -1,6 +1,6 @@
 # Generate unique storage name
 resource "random_id" "tectonic_storage_name" {
-  byte_length = 4
+  byte_length = 2
 }
 
 resource "azurerm_storage_account" "tectonic_worker" {

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -73,7 +73,7 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
   }
 
   os_profile {
-    computer_name  = "${format("%s-%s-%03d", var.cluster_name, var.role, count.index + 1)}"
+    computer_name  = "${format("%s%s%03d", var.cluster_name, "w", count.index + 1)}"
     admin_username = "core"
     admin_password = ""
     custom_data    = "${base64encode("${data.ignition_config.worker.rendered}")}"

--- a/modules/azure/worker-ss/workers.tf
+++ b/modules/azure/worker-ss/workers.tf
@@ -7,7 +7,7 @@ resource "random_id" "tectonic_storage_name" {
 }
 
 resource "azurerm_storage_account" "tectonic_worker" {
-  name                = "${var.cluster_prefix}${random_id.tectonic_storage_name.hex}wrk"
+  name                = "${var.cluster_name}${random_id.tectonic_storage_name.hex}wrk"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"

--- a/modules/azure/worker-ss/workers.tf
+++ b/modules/azure/worker-ss/workers.tf
@@ -3,7 +3,7 @@
 
 # Generate unique storage name
 resource "random_id" "tectonic_storage_name" {
-  byte_length = 4
+  byte_length = 2
 }
 
 resource "azurerm_storage_account" "tectonic_worker" {

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -44,7 +44,8 @@ module "etcd" {
 
   etcd_count            = "${var.tectonic_etcd_count}"
   base_domain           = "${var.tectonic_base_domain}"
-  cluster_name          = "${var.tectonic_cluster_name}"
+  cluster_prefix        = "${module.tectonic.prefix}"
+  cluster_name          = "${module.tectonic.name}"
   public_ssh_key        = "${var.tectonic_azure_ssh_key}"
   virtual_network       = "${module.vnet.vnet_id}"
   subnet                = "${module.vnet.master_subnet}"


### PR DESCRIPTION
We're doing a few things here...
* Switch byte_length to 2 to shorten `random_id.<name>.hex` to 4-characters (instead of 8)
* Shorten `proxy` to `p` for proxy server's storage_account_name
* Fix etcd resource names
* Use custom, shorter node naming